### PR TITLE
feat: Add addon configuration page links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ coverage
 secrets.json
 config.local.json
 *.secret
+
+# Claude Code files
+CLAUDE.local.md

--- a/src/components/saved-addons/SavedAddonCard.tsx
+++ b/src/components/saved-addons/SavedAddonCard.tsx
@@ -10,11 +10,11 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { useToast } from '@/hooks/use-toast'
-import { getStremioLink, maskUrl } from '@/lib/utils'
+import { maskUrl, getAddonConfigureUrl } from '@/lib/utils'
 import { useAddonStore } from '@/store/addonStore'
 import { useUIStore } from '@/store/uiStore'
 import { SavedAddon } from '@/types/saved-addon'
-import { Copy, ExternalLink, MoreVertical, Pencil, RefreshCw, Trash2 } from 'lucide-react'
+import { Copy, MoreVertical, Pencil, RefreshCw, Settings, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { SavedAddonDetails } from './SavedAddonDetails'
 
@@ -60,9 +60,10 @@ export function SavedAddonCard({ savedAddon, latestVersion, onUpdate }: SavedAdd
     })
   }
 
-  const handleOpenInStremio = (e: React.MouseEvent) => {
+  const handleOpenConfiguration = (e: React.MouseEvent) => {
     e.stopPropagation()
-    window.location.href = getStremioLink(savedAddon.installUrl)
+    const configUrl = getAddonConfigureUrl(savedAddon.installUrl)
+    window.open(configUrl, '_blank', 'noopener,noreferrer')
   }
 
   const getHealthStatusColor = () => {
@@ -205,15 +206,17 @@ export function SavedAddonCard({ savedAddon, latestVersion, onUpdate }: SavedAdd
                 </span>
                 <Copy className="h-3 w-3 shrink-0 opacity-50 group-hover:opacity-100 transition-opacity" />
               </button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 shrink-0"
-                onClick={handleOpenInStremio}
-                title="Open in Stremio"
-              >
-                <ExternalLink className="h-4 w-4" />
-              </Button>
+              {savedAddon.manifest.behaviorHints?.configurable && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 shrink-0"
+                  onClick={handleOpenConfiguration}
+                  title="Configure Addon"
+                >
+                  <Settings className="h-4 w-4" />
+                </Button>
+              )}
             </div>
 
             {/* Update Button */}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,3 +31,7 @@ export function maskUrl(url: string): string {
 export function getStremioLink(url: string): string {
   return url.replace(/^https?:\/\//, 'stremio://')
 }
+
+export function getAddonConfigureUrl(installUrl: string): string {
+  return installUrl.replace('manifest.json', 'configure')
+}


### PR DESCRIPTION
## Summary

Adds functionality to open addon configuration pages when clicking the settings icon on saved addon cards. The button only appears for addons that have the `configurable` behavior hint set to true.

## Changes

- ✨ Add `getAddonConfigureUrl()` utility to construct configuration URLs from install URLs
- 🔄 Replace "Open in Stremio" button with conditional "Configure Addon" button  
- 🎨 Use Settings (cog) icon for better UX (instead of ExternalLink)
- 🔒 Open configuration pages in new tab with security flags (`noopener,noreferrer`)
- 🔗 Preserve configuration tokens in URLs (e.g., `/abc123/manifest.json` → `/abc123/configure`)

## Implementation Details

The implementation matches Stremio's approach:
- Simple string replacement: `manifest.json` → `configure`
- Conditional rendering based on `addon.manifest.behaviorHints.configurable` flag
- Only shows configuration button for addons that support configuration (e.g., AIOMetadata, Debridio, Torrentio)

## Testing


https://github.com/user-attachments/assets/85725f67-45d6-498e-8db0-0fe81b051779




## Closes

Fixes #6