### PR TITLE
Fix mobile drag-and-drop scroll conflicts

### DIFF
--- a/src/components/addons/AddonReorderDialog.tsx
+++ b/src/components/addons/AddonReorderDialog.tsx
@@ -3,7 +3,8 @@ import {
   DndContext,
   closestCenter,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   useSensor,
   useSensors,
   DragEndEvent,
@@ -14,7 +15,14 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { AddonDescriptor } from '@/types/addon'
 import { SortableAddonItem } from './SortableAddonItem'
@@ -47,7 +55,16 @@ export function AddonReorderDialog({
   }, [open, addons])
 
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    useSensor(MouseSensor, {
+      activationConstraint: {
+        distance: 5, // Prevent accidental clicks from triggering drag
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        distance: 5, // Prevent accidental touches from triggering drag
+      },
+    }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     })
@@ -105,33 +122,20 @@ export function AddonReorderDialog({
             >
               <div className="space-y-2">
                 {items.map((addon) => (
-                  <SortableAddonItem
-                    key={addon.manifest.id}
-                    id={addon.manifest.id}
-                    addon={addon}
-                  />
+                  <SortableAddonItem key={addon.manifest.id} id={addon.manifest.id} addon={addon} />
                 ))}
               </div>
             </SortableContext>
           </DndContext>
         </div>
 
-        {error && (
-          <p className="text-sm text-destructive">{error}</p>
-        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
 
         <DialogFooter>
-          <Button
-            variant="outline"
-            onClick={handleCancel}
-            disabled={saving}
-          >
+          <Button variant="outline" onClick={handleCancel} disabled={saving}>
             Cancel
           </Button>
-          <Button
-            onClick={handleSave}
-            disabled={saving}
-          >
+          <Button onClick={handleSave} disabled={saving}>
             {saving ? 'Saving...' : 'Save'}
           </Button>
         </DialogFooter>

--- a/src/components/addons/SortableAddonItem.tsx
+++ b/src/components/addons/SortableAddonItem.tsx
@@ -9,14 +9,9 @@ interface SortableAddonItemProps {
 }
 
 export function SortableAddonItem({ addon, id }: SortableAddonItemProps) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id })
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+  })
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -38,6 +33,7 @@ export function SortableAddonItem({ addon, id }: SortableAddonItemProps) {
         {...attributes}
         {...listeners}
         className="cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground transition-colors"
+        style={{ touchAction: 'none' }}
       >
         <GripVertical className="h-5 w-5" />
       </div>
@@ -57,18 +53,14 @@ export function SortableAddonItem({ addon, id }: SortableAddonItemProps) {
       {/* Addon Info */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <h3 className="font-medium text-sm truncate">
-            {addon.manifest.name}
-          </h3>
+          <h3 className="font-medium text-sm truncate">{addon.manifest.name}</h3>
           {(addon.flags?.protected || addon.flags?.official) && (
             <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded flex-shrink-0">
               {addon.flags?.protected ? 'Protected' : 'Official'}
             </span>
           )}
         </div>
-        <p className="text-xs text-muted-foreground">
-          v{addon.manifest.version}
-        </p>
+        <p className="text-xs text-muted-foreground">v{addon.manifest.version}</p>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
Fixes #2

Resolves scroll conflicts on mobile devices when dragging addon items in the reorder dialog.

## Changes
- Replaced `PointerSensor` with separate `MouseSensor` and `TouchSensor`
- Added 5px activation constraint to both sensors to prevent accidental drag
- Added `touch-action: none` CSS to drag handle to prevent scroll gestures

## Implementation
- **MouseSensor**: 5px distance constraint for desktop (prevents accidental clicks)
- **TouchSensor**: 5px distance constraint for mobile (prevents accidental touches)
- **CSS**: `touch-action: none` on drag handle only (preserves dialog scrolling)

## Test Plan

### Before
https://github.com/user-attachments/assets/ef6ba791-080f-4f4c-bef4-530c308e25f6


### After
https://github.com/user-attachments/assets/05176d00-fd53-4cfb-bf18-42f800b50b57



## Devices to Test
- iPhone (Safari)
- Android phone (Chrome)
- iPad (Safari)
- Desktop browser