### PR TITLE
feat: Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Build artifacts
+dist
+node_modules
+
+# Development files
+.git
+.gitignore
+.vscode
+.husky
+*.log
+
+# Documentation (keep README.md)
+*.md
+!README.md
+
+# Config files not needed in container
+.eslintrc*
+.prettierrc*
+
+# Environment files
+.env*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Docker files
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Build stage
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files for dependency installation
+COPY package*.json ./
+
+# Install dependencies with clean install for reproducible builds
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+
+# Copy built assets from builder stage
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Copy nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Expose port 80
+EXPOSE 80
+
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Browsers treat `localhost` as a secure context even over HTTP, so encryption wor
 
 #### Network Access from Other Devices
 
-If you need to access the app from other devices (phone, tablet, another computer), you have three options:
+If you need to access the app from other devices (phone, tablet, another computer), you have two options:
 
 ##### Option 1: Use a Reverse Proxy (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,58 @@ The app will be available at `http://localhost:5173`
 
 The app will be automatically deployed on every push to your main branch.
 
+### Docker
+
+> **⚠️ Important: Web Crypto API Requirement**
+>
+> This app uses the **Web Crypto API** to encrypt Stremio credentials locally. Browsers require a **secure context** (HTTPS or localhost) for this to work. Accessing via local IP address (e.g., `http://192.168.1.50:8080`) will cause encryption errors unless you use one of the solutions below.
+
+#### Quick Start (Localhost Only)
+
+```bash
+# Using docker-compose (recommended)
+docker-compose up -d
+
+# Or using docker run
+docker build -t stremio-account-manager .
+docker run -d -p 8080:80 --name stremio-account-manager stremio-account-manager
+```
+
+**Access:** http://localhost:8080
+
+Browsers treat `localhost` as a secure context even over HTTP, so encryption works without any additional setup.
+
+#### Network Access from Other Devices
+
+If you need to access the app from other devices (phone, tablet, another computer), you have three options:
+
+##### Option 1: Use a Reverse Proxy (Recommended)
+
+Set up a reverse proxy like [Nginx Proxy Manager](https://nginxproxymanager.com/), [Caddy](https://caddyserver.com/), or [Traefik](https://traefik.io/) to serve the app over HTTPS with an SSL certificate.
+
+##### Option 2: Browser Bypass (Chrome/Edge Only)
+
+Force Chrome or Edge to treat your server's IP as secure:
+
+1. Open Chrome or Edge and navigate to: `chrome://flags/#unsafely-treat-insecure-origin-as-secure`
+2. Add your server's address: `http://192.168.x.x:8080` (replace with your actual IP)
+3. Change the dropdown to **Enabled**
+4. Relaunch your browser
+5. Access the app at `http://YOUR_IP:8080`
+
+**Note:** This is a workaround for development/personal use. It only works in Chrome/Edge and must be configured on each device.
+
+#### Stopping the Container
+
+```bash
+# Using docker-compose
+docker-compose down
+
+# Or using docker
+docker stop stremio-account-manager
+docker rm stremio-account-manager
+```
+
 ## Contributing
 
 Contributions are welcome! Please open a pull request with your changes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  app:
+    build: .
+    container_name: stremio-account-manager
+    restart: unless-stopped
+    ports:
+      - "8080:80"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA routing - fallback to index.html for all routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds complete Docker support for self-hosted deployment
- Multi-stage Dockerfile (Node.js build + nginx production)
- Docker Compose configuration for easy deployment
- Minimal nginx config optimized for simplicity (SPA routing only)
- Comprehensive documentation for localhost and network access

## Changes
- **Dockerfile**: Multi-stage build with Node.js 18 and nginx Alpine
- **docker-compose.yml**: Simple single-service configuration
- **nginx.conf**: Minimal config with just SPA routing (try_files fallback)
- **.dockerignore**: Excludes unnecessary files from build context
- **README.md**: Added Docker deployment section with Web Crypto API security warnings

## Documentation
- Instructions for localhost deployment (secure context by default)
- Options for network access (reverse proxy, browser flags)
- Container management commands

## Test Plan
- [ ] Build Docker image successfully
- [ ] Run container and access via localhost:8080
- [ ] Verify SPA routing works (refresh on any route)
- [ ] Test Web Crypto API encryption functionality
- [ ] Verify docker-compose up/down commands work

Closes #1